### PR TITLE
ASNIDE-255 Made autoindention less forceful

### DIFF
--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -374,6 +374,7 @@ SOURCES += \
     tests/sourcemapper_tests.cpp \
     tests/modelvalidityguard_tests.cpp \
     tests/linkcreator_tests.cpp \
+    tests/indenter_tests.cpp \
     \
     tests/networkreply.cpp \
     tests/parsingserviceproviderstub.cpp \
@@ -406,6 +407,7 @@ HEADERS += \
     tests/sourcemapper_tests.h \
     tests/modelvalidityguard_tests.h \
     tests/linkcreator_tests.h \
+    tests/indenter_tests.h \
     \
     tests/networkreply.h \
     tests/parsingserviceproviderstub.h \

--- a/src/asn1acn.cpp
+++ b/src/asn1acn.cpp
@@ -79,10 +79,11 @@
 #include "tests/autocompleter_tests.h"
 #include "tests/sourcemapper_tests.h"
 #include "tests/modelvalidityguard_tests.h"
+#include "tests/linkcreator_tests.h"
+#include "tests/indenter_tests.h"
 #include "libraries/tests/metadatacheckstatehandler_tests.h"
 #include "libraries/tests/metadatamodel_tests.h"
 #include "libraries/tests/filemodel_tests.h"
-#include "tests/linkcreator_tests.h"
 #include "libraries/tests/modulemetadataparser_tests.h"
 #include "libraries/tests/generalmetadataparser_tests.h"
 #include "tree-views/tests/displayrolevisitor_tests.h"
@@ -315,6 +316,7 @@ QList<QObject *> Asn1AcnPlugin::createTestObjects() const
             << new Tests::SourceMapperTests
             << new Tests::ModelValidityGuardTests
             << new Tests::LinkCreatorTests
+            << new Tests::IndenterTests
                ;
 }
 #endif

--- a/src/indenter.cpp
+++ b/src/indenter.cpp
@@ -25,6 +25,8 @@
 
 #include "indenter.h"
 
+#include <QRegularExpression>
+
 #include <texteditor/tabsettings.h>
 
 using namespace Asn1Acn::Internal;
@@ -60,6 +62,10 @@ int Indenter::indentFor(const QTextBlock &block,
     QTextBlock previous = block.previous();
     if (!previous.isValid())
         return 0;
+
+    QString currentText = block.text();
+    if (!currentText.remove(QRegularExpression("[{}]")).trimmed().isEmpty())
+        return tabSettings.indentationColumn(block.text());
 
     QString previousText = previous.text();
     while (previousText.trimmed().isEmpty()) {

--- a/src/tests/indenter_tests.cpp
+++ b/src/tests/indenter_tests.cpp
@@ -1,0 +1,165 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Space sp. z o. o.
+** Contact: http://n7space.com
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+#include "indenter_tests.h"
+
+#include <QtTest>
+
+#include <QTextBlock>
+#include <QTextDocument>
+
+#include <texteditor/tabsettings.h>
+
+using namespace Asn1Acn::Internal::Tests;
+
+static const int TAB_SIZE = 4;
+static const int INDENT_SIZE = 4;
+
+IndenterTests::IndenterTests(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void IndenterTests::initTestCase()
+{
+    m_indenter = new Indenter;
+
+    m_document = new QTextDocument;
+    m_document->setPlainText(
+                /*  0 */  "    TestingAutocompletion DEFINITIONS ::= BEGIN\n"
+                /*  1 */  "    EXPORTS ALL;\n"
+                /*  2 */  "    IMPORTS\n"
+                /*  3 */  "        MyInt FROM MyModelName;\n"
+                /*  4 */  "        \n"
+                /*  5 */  "    MySequence ::= SEQUENCE {\n"
+                /*  6 */  "        a INTEGER\n"
+                /*  7 */  "    }\n"
+                /*  8 */  "    \n"
+                /*  9 */  "        OtherSequence ::= SEQUENCE\n"
+                /* 10 */  "        {\n"
+                /* 11 */  "            \n"
+                /* 12 */  "            \n"
+                /* 13 */  "            b INTEGER\n"
+                /* 14 */  "            \n"
+                /* 15 */  "            \n"
+                /* 16 */  "        }\n"
+                /* 17 */  "    \n"
+                /* 18 */  "    END\n"
+                );
+
+
+    m_tabSettings = new TextEditor::TabSettings(TextEditor::TabSettings::SpacesOnlyTabPolicy,
+                                                4,
+                                                4,
+                                                TextEditor::TabSettings::NoContinuationAlign);
+}
+
+void IndenterTests::cleanupTestCase()
+{
+    delete m_indenter;
+    delete m_document;
+    delete m_tabSettings;
+}
+
+void IndenterTests::test_curlyBracketsAreElectric()
+{
+    Indenter indenter;
+
+    QVERIFY(indenter.isElectricCharacter(QLatin1Char('{')));
+    QVERIFY(indenter.isElectricCharacter(QLatin1Char('}')));
+}
+
+void IndenterTests::test_firstLine()
+{
+    const auto block = m_document->findBlockByLineNumber(0);
+    const int indent = m_indenter->indentFor(block, *m_tabSettings);
+
+    QCOMPARE(indent, 0);
+}
+
+void IndenterTests::test_normalNonEmptyLine()
+{
+    const auto block = m_document->findBlockByLineNumber(1);
+    const int indent = m_indenter->indentFor(block, *m_tabSettings);
+
+    QCOMPARE(indent, INDENT_SIZE);
+}
+
+void IndenterTests::test_normalEmptyLine()
+{
+    const auto block = m_document->findBlockByLineNumber(4);
+    const int indent = m_indenter->indentFor(block, *m_tabSettings);
+
+    QCOMPARE(indent, 2 * INDENT_SIZE);
+}
+
+void IndenterTests::test_bracketCloseLine()
+{
+    auto block = m_document->findBlockByLineNumber(7);
+    int indent = m_indenter->indentFor(block, *m_tabSettings);
+
+    QCOMPARE(indent, INDENT_SIZE);
+
+    block = m_document->findBlockByLineNumber(16);
+    indent = m_indenter->indentFor(block, *m_tabSettings);
+
+    QCOMPARE(indent, 2 * INDENT_SIZE);
+}
+
+void IndenterTests::test_afterBracketCloseLine()
+{
+    auto block = m_document->findBlockByLineNumber(17);
+    int indent = m_indenter->indentFor(block, *m_tabSettings);
+
+    QCOMPARE(indent, INDENT_SIZE);
+}
+
+void IndenterTests::test_afterBracketOpenLine()
+{
+    auto block = m_document->findBlockByLineNumber(6);
+    int indent = m_indenter->indentFor(block, *m_tabSettings);
+
+    QCOMPARE(indent, 2 * INDENT_SIZE);
+
+    block = m_document->findBlockByLineNumber(11);
+    indent = m_indenter->indentFor(block, *m_tabSettings);
+
+    QCOMPARE(indent, 3 * INDENT_SIZE);
+}
+
+void IndenterTests::test_bracketOpenInManuallyIndentedNonEmptyLine()
+{
+    auto block = m_document->findBlockByLineNumber(5);
+    int indent = m_indenter->indentFor(block, *m_tabSettings);
+
+    QCOMPARE(indent, INDENT_SIZE);
+}
+
+void IndenterTests::test_afterBracketOpenAndNewLinesLine()
+{
+    auto block = m_document->findBlockByLineNumber(13);
+    int indent = m_indenter->indentFor(block, *m_tabSettings);
+
+    QCOMPARE(indent, 3 * INDENT_SIZE);
+}

--- a/src/tests/indenter_tests.h
+++ b/src/tests/indenter_tests.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Space sp. z o. o.
+** Contact: http://n7space.com
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+
+#include "../indenter.h"
+
+namespace Asn1Acn {
+namespace Internal {
+namespace Tests {
+
+class IndenterTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit IndenterTests(QObject *parent = 0);
+
+private slots:
+    void initTestCase();
+    void cleanupTestCase();
+
+    void test_curlyBracketsAreElectric();
+
+    void test_firstLine();
+
+    void test_normalNonEmptyLine();
+    void test_normalEmptyLine();
+
+    void test_bracketCloseLine();
+    void test_afterBracketCloseLine();
+
+    void test_afterBracketOpenLine();
+    void test_bracketOpenInManuallyIndentedNonEmptyLine();
+    void test_afterBracketOpenAndNewLinesLine();
+
+private:
+    Indenter *m_indenter;
+    QTextDocument *m_document;
+
+    TextEditor::TabSettings *m_tabSettings;
+};
+
+} // namespace Tests
+} // namespace Internal
+} // namespace Asn1Acn


### PR DESCRIPTION
The idea to fix the issue is to assume, that if the line consist of more than curly bracket, than it is correctly indented. Rationale: In scenario, when code transits from:
```
1. firstLine
2. otherLine
```
to 
```
1. firstLine
2. otherLine {
```
The `otherLine` was always indented to `firstLine`. However, I believe there is no need to do so, as the lines would already be indented to the same level, because this is what happens after pressing `enter` at the end of line `firstLine`. This leads to conclusion, that if transition is from: 
```
1.     firstLine
2. otherLine
```
to 
```
1.     firstLine
2. otherLine {
```
there is no need to auto indent the `otherLine` as it must have been set this way deliberately by the user. 