### PR TITLE
Fixed OutlineIndexUpdaterTests occasionally failing

### DIFF
--- a/src/tests/projectcontenthandler_tests.cpp
+++ b/src/tests/projectcontenthandler_tests.cpp
@@ -38,11 +38,17 @@ using namespace Asn1Acn::Internal::Tests;
 
 ProjectContentHandlerTests::ProjectContentHandlerTests(QObject *parent)
     : QObject(parent)
-    , m_storage(ParsedDataStorage::instance())
-    , m_guard(ModelValidityGuard::instance())
+    , m_storage(new ParsedDataStorage)
+    , m_guard(new ModelValidityGuard)
     , m_createProcessor([](const QString &)->DocumentProcessor * { return new DocumentProcessorStub(); })
 {
     m_fileTypes << "_ERROR_" << "_FAILED_" << "_SUCCESS_";
+}
+
+ProjectContentHandlerTests::~ProjectContentHandlerTests()
+{
+    delete m_storage;
+    delete m_guard;
 }
 
 void ProjectContentHandlerTests::test_singleProjectAddedAndRemoved()

--- a/src/tests/projectcontenthandler_tests.h
+++ b/src/tests/projectcontenthandler_tests.h
@@ -41,6 +41,7 @@ class ProjectContentHandlerTests : public QObject
 
 public:
     explicit ProjectContentHandlerTests(QObject *parent = 0);
+    ~ProjectContentHandlerTests();
 
 private slots:
     void test_singleProjectAddedAndRemoved();


### PR DESCRIPTION
The reason for the test failing was the same as previously, however this time I found the way to reproduce issue locally by executing tests in given order, so I believe it will not cause any surprises in future. 