### PR TITLE
ASNIDE-271 Added enabling import component menu according to currentl…

### DIFF
--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -177,7 +177,8 @@ SOURCES += \
     sourcemapper.cpp \
     typeslocator.cpp \
     modelvalidityguard.cpp \
-    usagesfinder.cpp
+    usagesfinder.cpp \
+    importmenuitemcontroller.cpp
 
 HEADERS += \
     completion/autocompleter.h \
@@ -325,7 +326,8 @@ HEADERS += \
     sourcemapper.h \
     typeslocator.h \
     modelvalidityguard.h \
-    usagesfinder.h
+    usagesfinder.h \
+    importmenuitemcontroller.h
 
 FORMS += \
     options-pages/general.ui \

--- a/src/asn1acn.cpp
+++ b/src/asn1acn.cpp
@@ -36,9 +36,6 @@
 
 #include <extensionsystem/pluginmanager.h>
 
-#include <projectexplorer/projectexplorer.h>
-#include <projectexplorer/session.h>
-
 #include <texteditor/texteditorconstants.h>
 
 #include "completion/asnsnippets.h"
@@ -68,6 +65,7 @@
 #include "typeslocator.h"
 #include "tr.h"
 #include "tools.h"
+#include "importmenuitemcontroller.h"
 
 #ifdef WITH_TESTS
 #include "tests/astxmlparser_tests.h"
@@ -239,9 +237,9 @@ void Asn1AcnPlugin::initializeImportFromAsnComponents(ActionContainer *toolsMenu
     Core::Command *command = Core::ActionManager::registerAction(importFromAsnComponents, Constants::IMPORT_FROM_COMPONENTS_LIBRARY);
     connect(importFromAsnComponents, &QAction::triggered, this, &Asn1AcnPlugin::raiseImportComponentWindow);
     toolsMenu->addAction(command);
-    importFromAsnComponents->setEnabled(ProjectExplorer::SessionManager::hasProjects());
-    connect(ProjectExplorer::ProjectExplorerPlugin::instance(), &ProjectExplorer::ProjectExplorerPlugin::fileListChanged,
-            [importFromAsnComponents]() { importFromAsnComponents->setEnabled(ProjectExplorer::SessionManager::hasProjects()); });
+    importFromAsnComponents->setEnabled(false);
+
+    new ImportMenuItemController(importFromAsnComponents, this);
 }
 
 void Asn1AcnPlugin::addToToolsMenu(ActionContainer *container)

--- a/src/importmenuitemcontroller.cpp
+++ b/src/importmenuitemcontroller.cpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+**
+** Copyright (C) 2018 N7 Space sp. z o. o.
+** Contact: http://n7space.com
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "importmenuitemcontroller.h"
+
+#include <QAction>
+
+#include <projectexplorer/projectexplorer.h>
+#include <projectexplorer/projectnodes.h>
+#include <projectexplorer/session.h>
+#include <projectexplorer/project.h>
+
+using namespace Asn1Acn::Internal;
+
+ImportMenuItemController::ImportMenuItemController(QAction *menuItem, QObject *parent)
+    : QObject(parent)
+    , m_menuItem(menuItem)
+    , m_currentProject(nullptr)
+{
+    connect(ProjectExplorer::SessionManager::instance(), &ProjectExplorer::SessionManager::startupProjectChanged,
+            this, &ImportMenuItemController::onActiveProjectChanged);
+
+    connect(ProjectExplorer::SessionManager::instance(), &ProjectExplorer::SessionManager::aboutToRemoveProject,
+            this, &ImportMenuItemController::onAboutToRemoveProject);
+}
+
+void ImportMenuItemController::onActiveProjectChanged(ProjectExplorer::Project *project)
+{
+    refreshCurrentProject(project);
+    if (m_currentProject == nullptr)
+        return;
+
+    const auto projectNode = m_currentProject->rootProjectNode();
+    if (projectNode == nullptr)
+        connect(project, &ProjectExplorer::Project::parsingFinished,
+                this, &ImportMenuItemController::onProjectLoadingFinished);
+
+    updateMenuItemState(projectNode);
+}
+
+void ImportMenuItemController::onAboutToRemoveProject(ProjectExplorer::Project *project)
+{
+    if (project == m_currentProject)
+        refreshCurrentProject(nullptr);
+}
+
+void ImportMenuItemController::onProjectLoadingFinished()
+{
+    updateMenuItemState(m_currentProject->rootProjectNode());
+}
+
+void ImportMenuItemController::refreshCurrentProject(ProjectExplorer::Project *project)
+{
+    if (m_currentProject != nullptr) {
+        disconnect(m_currentProject, &ProjectExplorer::Project::parsingFinished,
+                   this, &ImportMenuItemController::onProjectLoadingFinished);
+        m_menuItem->setEnabled(false);
+    }
+
+    m_currentProject = project;
+}
+
+void ImportMenuItemController::updateMenuItemState(const ProjectExplorer::ProjectNode *node)
+{
+    if (node == nullptr)
+        return;
+
+    m_menuItem->setEnabled(node->supportsAction(ProjectExplorer::AddExistingFile, node));
+}

--- a/src/importmenuitemcontroller.h
+++ b/src/importmenuitemcontroller.h
@@ -1,0 +1,61 @@
+/****************************************************************************
+**
+** Copyright (C) 2018 N7 Space sp. z o. o.
+** Contact: http://n7space.com
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+#pragma once
+
+#include <QObject>
+
+class QAction;
+
+namespace ProjectExplorer {
+class Project;
+class ProjectNode;
+}
+
+namespace Asn1Acn {
+namespace Internal {
+
+class ImportMenuItemController : public QObject
+{
+    Q_OBJECT
+
+public:
+    ImportMenuItemController(QAction *menuItem, QObject *parent = nullptr);
+
+private slots:
+    void onActiveProjectChanged(ProjectExplorer::Project *project);
+    void onProjectLoadingFinished();
+
+    void onAboutToRemoveProject(ProjectExplorer::Project *project);
+
+private:
+    void refreshCurrentProject(ProjectExplorer::Project *project);
+    void updateMenuItemState(const ProjectExplorer::ProjectNode *node);
+
+    QAction *m_menuItem;
+    ProjectExplorer::Project *m_currentProject;
+};
+
+} // namespace Internal
+} // namespace Asn1Acn


### PR DESCRIPTION
…y active project

Importing files in CMake could not be implemented easily, so I decided to disable _Import From ASN.1 components library_ menu item, when currently active project does not support adding files. 