### PR TITLE
ASNIDE-273 Added handling more than one definition per line in data v…

### DIFF
--- a/src/tree-views/synchronizedindexupdater.h
+++ b/src/tree-views/synchronizedindexupdater.h
@@ -31,6 +31,8 @@
 #include <texteditor/texteditor.h>
 #include <utils/fileutils.h>
 
+#include <data/sourcelocation.h>
+
 #include "indexupdater.h"
 
 class QTreeView;
@@ -58,8 +60,8 @@ private:
     void updateNow();
     void createUpdateTimer();
 
-    int getCurrentLine() const;
-    QModelIndex getIndexFromParent(const QModelIndex &parentIndex, const int line, const QString &fileName) const;
+    Data::SourceLocation getCurrentLocation() const;
+    QModelIndex getIndexFromParent(const QModelIndex &parentIndex, Data::SourceLocation currentLocation) const;
 
     TextEditor::TextEditorWidget *m_editorWidget;
     QTimer *m_updateIndexTimer;

--- a/src/tree-views/tests/outlineindexupdater_tests.h
+++ b/src/tree-views/tests/outlineindexupdater_tests.h
@@ -44,12 +44,12 @@ public:
 
 private slots:
     void test_setEmptyEditor();
-    void test_setNonEmpytEditorInitialCursorPosition();
     void test_setNonEmpytEditorChangedPosition();
 
     void test_cursorMovedToModule();
     void test_cursorMovedToTypeDefinition();
     void test_cursorMovedToEmptyLine();
+    void test_cursorMovedToSecondDefinitionInLine();
 
     void test_forceUpdate();
     void test_forceUpdateAfterCursorMoved();


### PR DESCRIPTION
…iew widgets

From now on, the item in tree view will be highlighted, after placing cursor within corresponding definition in tree view (previously after placing cursor anywhere in the line, which contained definition.). This resolves the issue, however I believe that the idea can be exploited further. Especially, in line as follows:
`Num1           ::=          INTEGER        Num2       ::=        INTEGER` placing cursor anywhere within `Num1           ::=          INTEGER` should highlight tree item corresponding to `Num1` and placing cursor anywhere within  `Num2       ::=        INTEGER` should highlight `Num2` tree item. The idea should not be introduced before switching to asn1sccV4 is finished, as this require change in ast parsing. 