### PR TITLE
ASNIDE-222 Parametrized instances are ignored when searching of type references

### DIFF
--- a/src/astxmlparser.h
+++ b/src/astxmlparser.h
@@ -67,6 +67,7 @@ private:
     QString readNameAttribute();
     int readLineAttribute();
     int readCharPossitionInLineAttribute();
+    bool isParametrizedTypeInstance() const;
 
     void readImportedModule();
     void readImportedValues(const QString &moduleName);
@@ -81,6 +82,8 @@ private:
     std::unique_ptr<Data::Types::Type> readReferenceType(const Data::SourceLocation &location);
     std::unique_ptr<Data::Types::Type> buildTypeFromName(const Data::SourceLocation &location,
                                                          const QStringRef &name);
+
+    void readTypeContents(const QStringRef &name);
     void readSequence();
     void readSequenceOf();
     void readChoice();

--- a/src/tests/astxmlparser_tests.h
+++ b/src/tests/astxmlparser_tests.h
@@ -60,6 +60,7 @@ private slots:
     void test_multipleImportedValues();
     void test_multipleModules();
     void test_multipleFiles();
+    void test_parametrizedInstancesContentsAreIgnored();
 
 private:
     void setXmlData(const QString &str);


### PR DESCRIPTION
George added "ParameterizedTypeInstance" attribute, so for now I'm just skipping parametrized instances. Maybe in future we'll get proper info about parametrized types instances...