### PR TITLE
ASNIDE-265 Fixed initial tree expansion in Outline view widget.

### DIFF
--- a/src/tree-views/outlinewidget.cpp
+++ b/src/tree-views/outlinewidget.cpp
@@ -42,7 +42,9 @@ using namespace Asn1Acn::Internal::TreeViews;
 
 OutlineWidget::OutlineWidget(Model *model, std::unique_ptr<OutlineIndexUpdaterFactory> factory)
     : TreeViewWidget(model, std::move(factory))
-{}
+{
+    m_treeView->expandAll();
+}
 
 bool OutlineWidgetFactory::supportsEditor(Core::IEditor *editor) const
 {

--- a/src/tree-views/treeviewwidget.cpp
+++ b/src/tree-views/treeviewwidget.cpp
@@ -57,9 +57,10 @@ void TreeView::contextMenuEvent(QContextMenuEvent *event)
 
 TreeViewWidget::TreeViewWidget(Model *model,
                                std::unique_ptr<IndexUpdaterFactory> indexUpdaterFactory)
-    : m_indexUpdaterFactory(std::move(indexUpdaterFactory))
+    : m_treeView(new TreeView(this))
+    , m_indexUpdaterFactory(std::move(indexUpdaterFactory))
+    , m_indexUpdater(nullptr)
     , m_model(model)
-    , m_treeView(new TreeView(this))
 {
     model->setParent(this);
 

--- a/src/tree-views/treeviewwidget.h
+++ b/src/tree-views/treeviewwidget.h
@@ -61,6 +61,8 @@ public slots:
     void updateSelection(const QModelIndexList &selected, const QModelIndex &current);
 
 protected:
+    TreeView *m_treeView;
+
 private:
     QLayout *createLayout();
     void expandItemsAbove(const QModelIndex &parent);
@@ -69,7 +71,6 @@ private:
     std::unique_ptr<IndexUpdater> m_indexUpdater;
 
     Model *m_model;
-    TreeView *m_treeView;
 };
 
 } // namespace TreeViews


### PR DESCRIPTION
This is what seems to provide best solution at the moment.