### PR TITLE
Removed awkward rootIndex() method from MetadataModel

### DIFF
--- a/src/libraries/filemodel.cpp
+++ b/src/libraries/filemodel.cpp
@@ -80,20 +80,20 @@ void FileModel::setItemCheck(const QModelIndex &index, const QVariant &value)
     emit dataChanged(index, index);
 }
 
-void FileModel::setChildrenCheck(const QModelIndex &index, const QVariant &value)
+void FileModel::setChildrenCheck(const QModelIndex &parent, const QVariant &value)
 {
-    if (!index.isValid())
+    if (!parent.isValid())
         return;
 
-    for (int i = 0; i < rowCount(index); ++i) {
-        for (int j = 0; j < columnCount(index); ++j) {
-            auto child = index.child(i, j);
+    for (int i = 0; i < rowCount(parent); ++i) {
+        for (int j = 0; j < columnCount(parent); ++j) {
+            const auto child = index(i, j, parent);
             changeCheckState(child, value);
             setChildrenCheck(child, value);
         }
     }
 
-    emit dataChanged(index.child(0, 0), index.child(rowCount(index), rowCount(index)));
+    emit dataChanged(parent.child(0, 0), parent.child(rowCount(parent), rowCount(parent)));
 }
 
 void FileModel::setParentCheck(const QModelIndex &index)

--- a/src/libraries/metadatacheckstatehandler.cpp
+++ b/src/libraries/metadatacheckstatehandler.cpp
@@ -84,11 +84,11 @@ bool MetadataCheckStateHandler::check(const QModelIndex &index, const Qt::CheckS
     return true;
 }
 
-bool MetadataCheckStateHandler::updateChildren(const QModelIndex &index, const Qt::CheckState state)
+bool MetadataCheckStateHandler::updateChildren(const QModelIndex &parent, const Qt::CheckState state)
 {
-    for (auto i = 0; i < m_model->rowCount(index); ++i) {
-        for (auto j = 0; j < m_model->columnCount(index); ++j) {
-            auto child = index.child(i, j);
+    for (auto i = 0; i < m_model->rowCount(parent); ++i) {
+        for (auto j = 0; j < m_model->columnCount(parent); ++j) {
+            auto child = m_model->index(i, j, parent);
 
             m_changedIndexes.insert(child, state);
 
@@ -155,7 +155,7 @@ bool MetadataCheckStateHandler::hasNoConflicts(const QModelIndex &index)
 
 QModelIndex MetadataCheckStateHandler::findRelative(const Metadata::Reference &reference) const
 {
-    const auto module = findChildByName(m_model->rootIndex(), reference.module());
+    const auto module = findChildByName(QModelIndex(), reference.module());
     const auto submodule = findChildByName(module, reference.submodule());
     return findChildByName(submodule, reference.element());
 }
@@ -163,12 +163,9 @@ QModelIndex MetadataCheckStateHandler::findRelative(const Metadata::Reference &r
 QModelIndex MetadataCheckStateHandler::findChildByName(const QModelIndex &parent,
                                                        const QString &name) const
 {
-    if (!parent.isValid())
-        return {};
-
     for (int i = 0; i < m_model->rowCount(parent); ++i) {
         for (int j = 0; j < m_model->columnCount(parent); ++j) {
-            auto child = parent.child(i, j);
+            auto child = m_model->index(i, j, parent);
             if (m_model->dataNode(child)->name() == name)
                 return child;
         }
@@ -184,7 +181,7 @@ Qt::CheckState MetadataCheckStateHandler::parentState(const QModelIndex &index,
 
     for (auto i = 0; i < m_model->rowCount(parent); ++i) {
         for (auto j = 0; j < m_model->columnCount(parent); ++j) {
-            const auto child = parent.child(i, j);
+            const auto child = m_model->index(i, j, parent);
 
             if (m_model->data(child, Qt::CheckStateRole) != state
                 && (!m_changedIndexes.contains(child) || m_changedIndexes.value(child) != state))

--- a/src/libraries/metadatacheckstatehandler.h
+++ b/src/libraries/metadatacheckstatehandler.h
@@ -53,7 +53,7 @@ private:
     bool uncheck(const QModelIndex &index);
     bool check(const QModelIndex &index, const Qt::CheckState state);
 
-    bool updateChildren(const QModelIndex &index, const Qt::CheckState state);
+    bool updateChildren(const QModelIndex &parent, const Qt::CheckState state);
     bool updateParent(const QModelIndex &index, const Qt::CheckState childState);
 
     bool handleRelatives(const QModelIndex &index);

--- a/src/libraries/metadatamodel.cpp
+++ b/src/libraries/metadatamodel.cpp
@@ -130,11 +130,6 @@ const QHash<QPersistentModelIndex, Qt::CheckState> &MetadataModel::selectedItems
     return m_selectedItems;
 }
 
-QModelIndex MetadataModel::rootIndex() const
-{
-    return createIndex(0, 0, const_cast<Metadata::LibraryNode *>(m_root));
-}
-
 void MetadataModel::selectItems(const MetadataCheckStateHandler::States &items)
 {
     for (auto it = items.begin(); it != items.end(); ++it) {

--- a/src/libraries/metadatamodel.h
+++ b/src/libraries/metadatamodel.h
@@ -50,7 +50,6 @@ public:
     int columnCount(const QModelIndex &parent) const override;
     bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 
-    QModelIndex rootIndex() const;
     const Metadata::LibraryNode *dataNode(const QModelIndex &index) const;
     const QHash<QPersistentModelIndex, Qt::CheckState> &selectedItems() const;
 

--- a/src/libraries/tests/metadatacheckstatehandler_tests.cpp
+++ b/src/libraries/tests/metadatacheckstatehandler_tests.cpp
@@ -87,7 +87,7 @@ QModelIndex getIndexByName(const MetadataModel *model, const QModelIndex &index,
 {
     for (int i = 0; i < model->rowCount(index); ++i) {
         for (int j = 0; j < model->columnCount(index); ++j) {
-            auto child = index.child(i, j);
+            auto child = model->index(i, j, index);
             if (model->dataNode(child)->name() == name)
                 return child;
 
@@ -105,7 +105,7 @@ void setDependecies(const MetadataModel *model,
                     const References &requires,
                     const References &conflicts)
 {
-    const auto ownerIndex = getIndexByName(model, model->rootIndex(), owner);
+    const auto ownerIndex = getIndexByName(model, QModelIndex(), owner);
     QVERIFY(ownerIndex.isValid());
 
     auto ownerNode = static_cast<Metadata::LibraryNode *>(ownerIndex.internalPointer());
@@ -132,7 +132,7 @@ void MetadataCheckStateHandlerTests::test_singleElementChecked()
     MetadataCheckStateHandler handler(model.get());
 
     auto index = getIndexByName(model.get(),
-                                model->rootIndex(),
+                                QModelIndex(),
                                 "library_module0_submodule0_element0");
     bool ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(ret);
@@ -156,12 +156,12 @@ void MetadataCheckStateHandlerTests::test_allParentChildrenChecked()
     MetadataCheckStateHandler handler(model.get());
 
     auto index = getIndexByName(model.get(),
-                                model->rootIndex(),
+                                QModelIndex(),
                                 "library_module0_submodule0_element0");
     bool ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(ret);
 
-    index = getIndexByName(model.get(), model->rootIndex(), "library_module0_submodule0_element1");
+    index = getIndexByName(model.get(), QModelIndex(), "library_module0_submodule0_element1");
     ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(ret);
 
@@ -193,7 +193,7 @@ void MetadataCheckStateHandlerTests::test_elementWithSingleRequirementChecked()
     setDependecies(model.get(), "library_module0_submodule0_element0", requirements, {});
 
     auto index = getIndexByName(model.get(),
-                                model->rootIndex(),
+                                QModelIndex(),
                                 "library_module0_submodule0_element0");
     bool ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(ret);
@@ -205,7 +205,7 @@ void MetadataCheckStateHandlerTests::test_elementWithSingleRequirementChecked()
     QCOMPARE(changed.value(index), Qt::Checked);
 
     auto required = getIndexByName(model.get(),
-                                   model->rootIndex(),
+                                   QModelIndex(),
                                    "library_module0_submodule0_element1");
     QVERIFY(changed.contains(required));
     QCOMPARE(changed.value(required), Qt::Checked);
@@ -228,7 +228,7 @@ void MetadataCheckStateHandlerTests::test_parentWithDependendtChildrenChecked()
                                         "library_module0_submodule0_element1");
     setDependecies(model.get(), "library_module0_submodule0_element0", requirements, {});
 
-    auto index = getIndexByName(model.get(), model->rootIndex(), "library_module0_submodule0");
+    auto index = getIndexByName(model.get(), QModelIndex(), "library_module0_submodule0");
     bool ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(ret);
 
@@ -237,7 +237,7 @@ void MetadataCheckStateHandlerTests::test_parentWithDependendtChildrenChecked()
 
     for (int i = 0; i < model->rowCount(index); ++i) {
         for (int j = 0; j < model->columnCount(index); ++j) {
-            const auto child = index.child(i, j);
+            const auto child = model->index(i, j, index);
             QVERIFY(changed.contains(child));
             QCOMPARE(changed.value(child), Qt::Checked);
         }
@@ -262,7 +262,7 @@ void MetadataCheckStateHandlerTests::test_elementWithRequirementInOtherModule()
     setDependecies(model.get(), "library_module0_submodule0_element0", requirements, {});
 
     auto index = getIndexByName(model.get(),
-                                model->rootIndex(),
+                                QModelIndex(),
                                 "library_module0_submodule0_element0");
     bool ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(ret);
@@ -279,7 +279,7 @@ void MetadataCheckStateHandlerTests::test_elementWithRequirementInOtherModule()
     }
 
     auto required = getIndexByName(model.get(),
-                                   model->rootIndex(),
+                                   QModelIndex(),
                                    "library_module1_submodule0_element0");
 
     QVERIFY(changed.contains(required));
@@ -310,7 +310,7 @@ void MetadataCheckStateHandlerTests::test_conflictingElementChecked()
     setDependecies(model.get(), "library_module0_submodule0_element0", {}, conflicts);
 
     auto index = getIndexByName(model.get(),
-                                model->rootIndex(),
+                                QModelIndex(),
                                 "library_module0_submodule0_element0");
     bool ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(ret);
@@ -320,7 +320,7 @@ void MetadataCheckStateHandlerTests::test_conflictingElementChecked()
     QCOMPARE(changed.value(index), Qt::Checked);
 
     auto conflictingIndex = getIndexByName(model.get(),
-                                           model->rootIndex(),
+                                           QModelIndex(),
                                            "library_module0_submodule0_element1");
     ret = handler.changeCheckStates(conflictingIndex, Qt::Checked);
 
@@ -345,11 +345,11 @@ void MetadataCheckStateHandlerTests::test_parentWithConflictingChildrenChecked()
                                      "library_module0_submodule0_element1");
     setDependecies(model.get(), "library_module0_submodule0_element0", {}, conflicts);
 
-    auto index = getIndexByName(model.get(), model->rootIndex(), "library_module0_submodule0");
+    auto index = getIndexByName(model.get(), QModelIndex(), "library_module0_submodule0");
     bool ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(!ret);
 
-    index = getIndexByName(model.get(), model->rootIndex(), "library_module0");
+    index = getIndexByName(model.get(), QModelIndex(), "library_module0");
     ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(!ret);
 }
@@ -372,7 +372,7 @@ void MetadataCheckStateHandlerTests::test_cyclicDependedncy()
                                         "library_module0_submodule0_element1");
     setDependecies(model.get(), "library_module0_submodule0_element0", requirements, {});
 
-    auto index = getIndexByName(model.get(), model->rootIndex(), "library_module0_submodule0");
+    auto index = getIndexByName(model.get(), QModelIndex(), "library_module0_submodule0");
     bool ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(ret);
 
@@ -381,7 +381,7 @@ void MetadataCheckStateHandlerTests::test_cyclicDependedncy()
 
     for (int i = 0; i < model->rowCount(index); ++i) {
         for (int j = 0; j < model->columnCount(index); ++j) {
-            const auto child = index.child(i, j);
+            const auto child = model->index(i, j, index);
             QVERIFY(changed.contains(child));
             QCOMPARE(changed.value(child), Qt::Checked);
         }
@@ -417,16 +417,16 @@ void MetadataCheckStateHandlerTests::test_parentNodeWithChildDependencyInOtherMo
                                         "library_module1_submodule0_element2");
     setDependecies(model.get(), "library_module1_submodule0_element1", requirements, {});
 
-    auto index = getIndexByName(model.get(), model->rootIndex(), "library_module0");
+    auto index = getIndexByName(model.get(), QModelIndex(), "library_module0");
     bool ret = handler.changeCheckStates(index, Qt::Checked);
     QVERIFY(ret);
 
     const auto &changed = handler.changedIndexes();
-    QVERIFY(changed.contains(getIndexByName(model.get(), model->rootIndex(), "library_module0")));
+    QVERIFY(changed.contains(getIndexByName(model.get(), QModelIndex(), "library_module0")));
     QVERIFY(changed.contains(
-        getIndexByName(model.get(), model->rootIndex(), "library_module1_submodule0_element0")));
+        getIndexByName(model.get(), QModelIndex(), "library_module1_submodule0_element0")));
     QVERIFY(changed.contains(
-        getIndexByName(model.get(), model->rootIndex(), "library_module1_submodule0_element1")));
+        getIndexByName(model.get(), QModelIndex(), "library_module1_submodule0_element1")));
     QVERIFY(changed.contains(
-        getIndexByName(model.get(), model->rootIndex(), "library_module1_submodule0_element2")));
+        getIndexByName(model.get(), QModelIndex(), "library_module1_submodule0_element2")));
 }


### PR DESCRIPTION
Question asked in latest review reminded me of other place, which would benefit greatly from changing usage of `parent.child(i, j)`  to `model->index(i, j , parent)`. This was especially itchy, due to const_cast usage. Thanks to changes in this PR, casting constness was removed.