### PR TITLE
ASNIDE-269 Increased indentation in qmake project file template

### DIFF
--- a/templates/wizards/projects/asn1acn/file.pro
+++ b/templates/wizards/projects/asn1acn/file.pro
@@ -4,11 +4,11 @@ CONFIG -= app_bundle
 CONFIG -= qt
 
 %{JS: if (%{AddAsnFile} && %{AddAcnFile})
-        'DISTFILES += \\\\ \n %{AsnRelativePath}/%{AsnFile} \\\\ \n %{AcnRelativePath}/%{AcnFile}'
+        'DISTFILES += \\\\ \n    %{AsnRelativePath}/%{AsnFile} \\\\ \n    %{AcnRelativePath}/%{AcnFile}'
       else if (%{AddAsnFile})
-        'DISTFILES += \\\\ \n %{AsnRelativePath}/%{AsnFile}'
+        'DISTFILES += \\\\ \n    %{AsnRelativePath}/%{AsnFile}'
       else if (%{AddAcnFile})
-        'DISTFILES += \\\\ \n %{AcnRelativePath}/%{AcnFile}'
+        'DISTFILES += \\\\ \n    %{AcnRelativePath}/%{AcnFile}'
       else
         'DISTFILES += ' }
 


### PR DESCRIPTION
Entries will now be indented equally, however entries added from .pro file template will be starting with `./` , while added through wizard will not be having this prefix. If really needed, this could be hacked, so both will miss the prefix. Other way might not be possible, as a result of internal ProjectExplorer implementation. 