### PR TITLE
ASNIDE-237 dependencies fixed in generated qmake project

### DIFF
--- a/templates/wizards/projects/asn1acn/generateFromAsn1.pri
+++ b/templates/wizards/projects/asn1acn/generateFromAsn1.pri
@@ -38,22 +38,23 @@ defineReplace(filterASN1ACNFiles) {
 
 ASN1ACNFILES = $$filterASN1ACNFiles($${DISTFILES})
 
-prepare.target += prepare
-prepare.commands += $$sprintf($$QMAKE_MKDIR_CMD, $$shell_quote($$ASN1SCC_PRODUCTS_DIR))
-prepare.commands += && $$sprintf($$QMAKE_MKDIR_CMD, $$shell_quote($$ASN1SCC_ICD_DIR))
-
-codeFromAsn1.target += codeFromAsn1
+codeFromAsn1.target += $${ASN1_MAIN_GENERATED_HEADER}
+codeFromAsn1.commands += $$sprintf($$QMAKE_MKDIR_CMD, $$shell_quote($$ASN1SCC_PRODUCTS_DIR))
+codeFromAsn1.commands += $$escape_expand(\\n\\t)
 codeFromAsn1.commands += $$ASN1SCC $${ASN1SCC_GENERATION_OPTIONS} -o $$shell_quote($$ASN1SCC_PRODUCTS_DIR) $$ASN1ACNFILES
-codeFromAsn1.depends += prepare
+codeFromAsn1.depends += $$ASN1ACNFILES
 
 icdFromAsn1.target += icdFromAsn1
-icdFromAsn1.commands += $$ASN1SCC $${ASN1SCC_ICD_OPTIONS} $$shell_quote($${ASN1SCC_ICD_DIR}/$${ASN1SCC_ICD_FILE}) $$ASN1ACNFILES
-icdFromAsn1.depends += prepare
+icdFromAsn1.commands += $$sprintf($$QMAKE_MKDIR_CMD, $$shell_quote($$ASN1SCC_ICD_DIR))
+icdFromAsn1.commands += $$escape_expand(\\n\\t)
+icdFromAsn1.commands += $$ASN1SCC $${ASN1SCC_ICD_OPTIONS} $$shell_quote($${ASN1SCC_ICD_DIR}/$${ASN1SCC_ICD_FILE}) $$ASN1ACNFILES  
+icdFromAsn1.depends += $$ASN1ACNFILES
 
 cleanGenerated.target += cleanGenerated
 cleanGenerated.commands += $$QMAKE_DEL_TREE $$shell_quote($$ASN1SCC_PRODUCTS_DIR)
+cleanGenerated.commands += $$escape_expand(\\n\\t)
 cleanGenerated.commands += $$QMAKE_DEL_TREE $$shell_quote($$ASN1SCC_ICD_DIR)
 clean.depends += cleanGenerated
 
-QMAKE_EXTRA_TARGETS += prepare codeFromAsn1 icdFromAsn1 cleanGenerated clean
-PRE_TARGETDEPS += prepare codeFromAsn1
+QMAKE_EXTRA_TARGETS += codeFromAsn1 icdFromAsn1 cleanGenerated clean
+PRE_TARGETDEPS += $${ASN1_MAIN_GENERATED_HEADER}

--- a/templates/wizards/projects/asn1acn/updateSourcesList.pri
+++ b/templates/wizards/projects/asn1acn/updateSourcesList.pri
@@ -21,6 +21,23 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
+ASN1_MAIN_GENERATED_HEADER = $${ASN1SCC_PRODUCTS_DIR}/asn1crt.h
+
+defineReplace(createDependencyOrder) {
+  file = $${1}
+  fileName = $${2}
+
+  eval($${file}_custom.target = $${file})
+  eval($${file}_custom.depends = $${ASN1_MAIN_GENERATED_HEADER})
+  eval(export($${file}_custom.target))
+  eval(export($${file}_custom.depends))
+
+  QMAKE_EXTRA_TARGETS += $${file}_custom
+  export(QMAKE_EXTRA_TARGETS)
+
+  return($$file)
+}
+
 defineReplace(createFileNames) {
     allFiles = $${1}
 
@@ -49,23 +66,13 @@ defineReplace(createEmptyFiles) {
     return($$files)
 }
 
-defineReplace(createHeadersList) {
-    headersNames = $${1}
-
-    for(name, headersNames) {
-        header = $$clean_path($${ASN1SCC_PRODUCTS_DIR}/$${name}.h)
-        headers += $$header
-    }
-
-    return($$createEmptyFiles($$headers))
-}
-
-defineReplace(createSourcesList) {
+defineReplace(createGeneratedFilesList) {
     sourcesNames = $${1}
+    extension = $${2}
 
     for(name, sourcesNames) {
-        source = $$clean_path($${ASN1SCC_PRODUCTS_DIR}/$${name}.c)
-        sources += $$source
+        source = $$clean_path($${ASN1SCC_PRODUCTS_DIR}/$${name}.$${extension})
+        sources += $$createDependencyOrder($$source, $$name)
     }
 
     return($$createEmptyFiles($$sources))
@@ -74,7 +81,7 @@ defineReplace(createSourcesList) {
 names = $$createFileNames($$DISTFILES)
 
 !isEmpty(names) {
-    PERSISTENT_HEADERS = $${ASN1SCC_PRODUCTS_DIR}/asn1crt.h
+    PERSISTENT_HEADERS = $${ASN1_MAIN_GENERATED_HEADER}
     PERSISTENT_SOURCES = $${ASN1SCC_PRODUCTS_DIR}/asn1crt.c $${ASN1SCC_PRODUCTS_DIR}/real.c
 
     contains(ASN1SCC_GENERATION_OPTIONS, -ACN) {
@@ -82,7 +89,7 @@ names = $$createFileNames($$DISTFILES)
     }
 }
 
-SOURCES += $$createSourcesList($$names) $$createEmptyFiles($$PERSISTENT_SOURCES)
-HEADERS += $$createHeadersList($$names) $$createEmptyFiles($$PERSISTENT_HEADERS)
+SOURCES += $$createGeneratedFilesList($$names, "c") $$createEmptyFiles($$PERSISTENT_SOURCES)
+HEADERS += $$createGeneratedFilesList($$names, "h") $$createEmptyFiles($$PERSISTENT_HEADERS)
 
 INCLUDEPATH += $$ASN1SCC_PRODUCTS_DIR


### PR DESCRIPTION
generated/asn1crt.h -depends-on-> `*.asn` (building it calls asn1.exe)
generated/`*.c` -depends-on-> generated/asn1crt.h (empty build rule)