### PR TITLE
ASNIDE-238 Handled change in library when wizard window is opened

### DIFF
--- a/src/libraries/librarystorage.cpp
+++ b/src/libraries/librarystorage.cpp
@@ -37,12 +37,11 @@ LibraryStorage *LibraryStorage::instance()
 
 void LibraryStorage::addLibrary(LibraryPtr library)
 {
-    QMutexLocker lock(&m_libraryMutex);
-
     emit aboutToChange();
-
-    m_libraries[library->name()] = std::move(library);
-
+    {
+        QMutexLocker lock(&m_libraryMutex);
+        m_libraries[library->name()] = std::move(library);
+    }
     emit changed();
 }
 
@@ -60,12 +59,11 @@ Metadata::General LibraryStorage::generalMetadata(const QString &path)
 
 void LibraryStorage::removeLibraries()
 {
-    QMutexLocker lock(&m_libraryMutex);
-
     emit aboutToChange();
-
-    m_libraries.clear();
-
+    {
+        QMutexLocker lock(&m_libraryMutex);
+        m_libraries.clear();
+    }
     emit changed();
 }
 

--- a/src/libraries/wizard/relationslabelscontroller.cpp
+++ b/src/libraries/wizard/relationslabelscontroller.cpp
@@ -43,6 +43,11 @@ RelationsLabelsController::RelationsLabelsController(MetadataModel *model,
     , m_conflictsTree(conflictsTree)
 {}
 
+RelationsLabelsController::~RelationsLabelsController()
+{
+    clearRelationsTrees();
+}
+
 namespace {
 void appendElementItems(const QList<Metadata::Reference> &references,
                         QHash<QString, QTreeWidgetItem *> &parents)

--- a/src/libraries/wizard/relationslabelscontroller.h
+++ b/src/libraries/wizard/relationslabelscontroller.h
@@ -46,6 +46,7 @@ public:
                               QTreeWidget *requiresTree,
                               QTreeWidget *conflictsTree,
                               QObject *parent = nullptr);
+    ~RelationsLabelsController();
 
 public slots:
     void onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);

--- a/src/libraries/wizard/selectcomponentspage.cpp
+++ b/src/libraries/wizard/selectcomponentspage.cpp
@@ -52,6 +52,16 @@ SelectComponentsPage::SelectComponentsPage(ComponentImporter &importer, QWidget 
             &QComboBox::currentTextChanged,
             this,
             &SelectComponentsPage::onComboTextChanged);
+
+    connect(LibraryStorage::instance(),
+            &LibraryStorage::aboutToChange,
+            this,
+            &SelectComponentsPage::onLibrariesInvalidated);
+
+    connect(LibraryStorage::instance(),
+            &LibraryStorage::changed,
+            this,
+            &SelectComponentsPage::onLibrariesValidated);
 }
 
 void SelectComponentsPage::initializePage()
@@ -75,6 +85,20 @@ void SelectComponentsPage::onComboTextChanged(const QString &text)
     setupModel(text);
 }
 
+void SelectComponentsPage::onLibrariesInvalidated()
+{
+    m_model.reset(nullptr);
+    m_selector.reset(nullptr);
+    m_labelsController.reset(nullptr);
+
+    m_ui.modulesView->setModel(nullptr);
+}
+
+void SelectComponentsPage::onLibrariesValidated()
+{
+    setupModel(m_currentKey);
+}
+
 void SelectComponentsPage::setLibPath()
 {
     m_libPath = field("builtInRadio").toBool() ? field("builtInCombo").toString()
@@ -84,6 +108,8 @@ void SelectComponentsPage::setLibPath()
 void SelectComponentsPage::setupModel(const QString &key)
 {
     QTC_ASSERT(key == METADATA_COMBO_KEY || key == FILESYSTEM_COMBO_KEY, return );
+
+    m_currentKey = key;
 
     if (key == METADATA_COMBO_KEY) {
         setupMetadaModel();

--- a/src/libraries/wizard/selectcomponentspage.h
+++ b/src/libraries/wizard/selectcomponentspage.h
@@ -61,6 +61,9 @@ public:
 private slots:
     void onComboTextChanged(const QString &text);
 
+    void onLibrariesInvalidated();
+    void onLibrariesValidated();
+
 private:
     void setLibPath();
 
@@ -71,6 +74,7 @@ private:
 
     Ui::SelectComponent m_ui;
     QString m_libPath;
+    QString m_currentKey;
 
     std::unique_ptr<QAbstractItemModel> m_model;
 


### PR DESCRIPTION
This prevents IDE from crashing when import component wizard is opened, and metadata files are edited externally. 