### PR TITLE
Fix for qmake and icd build issue

### DIFF
--- a/src/buildicdstep.cpp
+++ b/src/buildicdstep.cpp
@@ -223,8 +223,25 @@ void BuildICDStep::finishInput(bool success)
     m_inputFuture = QFutureInterface<bool>();
 }
 
+namespace {
+QString quoteOne(const QString &file)
+{
+    return QLatin1Char('"') + file + QLatin1Char('"');
+}
+
+QStringList quoteList(const QStringList &files)
+{
+    QStringList res;
+    for (const auto &file : files)
+        res << quoteOne(file);
+    return res;
+}
+} // namespace
+
 QString BuildICDStep::argument()
 {
-    QString files = m_sources.join(QLatin1Char(' '));
-    return files + QString(" -icdAcn ") + m_outputPath + m_outputFilename;
+    const auto in = quoteList(m_sources).join(QLatin1Char(' '));
+    const auto out = quoteOne(m_outputPath + m_outputFilename);
+
+    return QString(" -icdAcn ") + out + QString(" ") + in;
 }

--- a/templates/wizards/projects/asn1acn/generateFromAsn1.pri
+++ b/templates/wizards/projects/asn1acn/generateFromAsn1.pri
@@ -29,25 +29,36 @@ defineReplace(filterASN1ACNFiles) {
         extension = $$last(splitted)
 
         equals(extension, asn)|equals(extension, asn1)|equals(extension, acn) {
-            fileNames += $$shell_quote($${_PRO_FILE_PWD_}/$${file})
+            fileNames += $${_PRO_FILE_PWD_}/$${file}
         }
     }
 
     return($$fileNames)
 }
 
+defineReplace(createASN1SCCInput) {
+    allFiles = $${1}
+
+    for(file, allFiles) {
+        fileNames += $$shell_quote($$file)
+    }
+
+    return($$fileNames)
+}
+
 ASN1ACNFILES = $$filterASN1ACNFiles($${DISTFILES})
+ASN1SCCINPUT = $$createASN1SCCInput($${ASN1ACNFILES})
 
 codeFromAsn1.target += $${ASN1_MAIN_GENERATED_HEADER}
 codeFromAsn1.commands += $$sprintf($$QMAKE_MKDIR_CMD, $$shell_quote($$ASN1SCC_SRC_DIR))
 codeFromAsn1.commands += $$escape_expand(\\n\\t)
-codeFromAsn1.commands += $$ASN1SCC $${ASN1SCC_GENERATION_OPTIONS} -o $$shell_quote($$ASN1SCC_SRC_DIR) $$ASN1ACNFILES
+codeFromAsn1.commands += $$ASN1SCC $${ASN1SCC_GENERATION_OPTIONS} -o $$shell_quote($$ASN1SCC_SRC_DIR) $$ASN1SCCINPUT
 codeFromAsn1.depends += $$ASN1ACNFILES
 
 icdFromAsn1.target += icdFromAsn1
 icdFromAsn1.commands += $$sprintf($$QMAKE_MKDIR_CMD, $$shell_quote($$ASN1SCC_ICD_DIR))
 icdFromAsn1.commands += $$escape_expand(\\n\\t)
-icdFromAsn1.commands += $$ASN1SCC $${ASN1SCC_ICD_OPTIONS} $$shell_quote($${ASN1SCC_ICD_DIR}/$${ASN1SCC_ICD_FILE}) $$ASN1ACNFILES  
+icdFromAsn1.commands += $$ASN1SCC $${ASN1SCC_ICD_OPTIONS} $$shell_quote($${ASN1SCC_ICD_DIR}/$${ASN1SCC_ICD_FILE}) $$ASN1SCCINPUT
 icdFromAsn1.depends += $$ASN1ACNFILES
 
 cleanGenerated.target += cleanGenerated

--- a/templates/wizards/projects/asn1acn/updateSourcesList.pri
+++ b/templates/wizards/projects/asn1acn/updateSourcesList.pri
@@ -27,12 +27,14 @@ defineReplace(createDependencyOrder) {
   file = $${1}
   fileName = $${2}
 
-  eval($${file}_custom.target = $${file})
-  eval($${file}_custom.depends = $${ASN1_MAIN_GENERATED_HEADER})
-  eval(export($${file}_custom.target))
-  eval(export($${file}_custom.depends))
+  stripedFile = $$replace(file, " ", "")
 
-  QMAKE_EXTRA_TARGETS += $${file}_custom
+  eval($${stripedFile}_custom.target = $${file})
+  eval($${stripedFile}_custom.depends = $${ASN1_MAIN_GENERATED_HEADER})
+  eval(export($${stripedFile}_custom.target))
+  eval(export($${stripedFile}_custom.depends))
+
+  QMAKE_EXTRA_TARGETS += $${stripedFile}_custom
   export(QMAKE_EXTRA_TARGETS)
 
   return($$file)
@@ -61,7 +63,7 @@ defineReplace(createEmptyFiles) {
     for(file, files) {
         write_file($$file, contents)
         unix|macx {
-            system("touch -t 197001020000 $${file}")
+            system("touch -t 197001020000 $$shell_quote($${file})")
         } else {
             touch($$file, $${QMAKE_QMAKE})
         }


### PR DESCRIPTION
The fix is included in last rc, and was tested on linux, clean linux and windows. 

I feel like I need to elaborate a little on this pull request. The goal of it is to fix qmake build in projects, which are in location containing spaces. The culprit breaking build in such situation was `eval` function, which after being called in following way: `eval($${file}_custom.target = $${file})` reported an error, if `$${file}` contained spaces. This happens because `$$file` is treated as two distinct arguments in such scenario, so the function call reports `Assignment needs exactly one word on the left hand side.`

Proposed solution is to strip spaces from the `$${file}`. My first idea was to used quotes (calling `shell_quote` on argument), but for some reason it does not work. I experimented with following part of code: 
````
  eval($${stripedFile}_custom.target = $${file})
  eval($${stripedFile}_custom.depends = $${ASN1_MAIN_GENERATED_HEADER})
  eval(export($${stripedFile}_custom.target))
  eval(export($${stripedFile}_custom.depends))

  target = $$eval($${stripedFile}_custom.target)
  depend = $$eval($${stripedFile}_custom.depends)

  message(target = $$target depend = $$depend)
````

The result when `stripedFile = myname` is `  Project MESSAGE: target = /home/asnide/workspace/projects/touchQmake/build-TestNameUniquness-spaceLocation-Desktop-Debug/asn1sccGenerated/src/NamesUniqunesSpacedLocation-MyModel.h depend = /home/asnide/workspace/projects/touchQmake/build-TestNameUniquness-spaceLocation-Desktop-Debug/asn1sccGenerated/src/asn1crt.h`

The result when `stripedFile = $$shell_quote(my name)` is  `Project MESSAGE: target = depend =`. The quoted argument is somehow not accepted, when creating targets. 

Reason, why in this context stripping spaces from paths might be applied, is that in function call `eval($${file}_custom.target = $${file})` , the content of `$${file}_custom` plays role only during generation of Makefile in qmake internals, and not Makefile itself. This means it does not need to correspond to any existing file, it just needs to be any unique identifier.

So is there a risk, that if there exist paths, which differs only with space in some directory name, the created identifiers will be conflicting? I believe, in current implementation, no. This is because `$${file}` is not a path to asn.1/acn file included in project, but path its .c analogue, which will be put in build directory. So what in fact matters, is not what the file directory is, but what the build is, and the latter is the same for all files included in project, so either all files will use striped paths, or none of them.

BTW1: for this reason, if there are files with the same name, but in different directories included in project, the build result would be undefined, due to overwrites in `$${BUILD_DIR}/asn1sccGenerated/src`. 

BTW2: To check the point I created new project, into which I added following models: (one via new project wizard, and the others via Project Context Menu -> Add new file). 

```
DISTFILES += \ 
    ../spaced dir/Model-In-Spaced-Location.asn1 \
    ../spaced dir/Model-In-Spaced-Location.acn \
    ../spaced dir/SecondInSpacedDirectory.acn \
    ../spaced dir/SecondInSpacedDirectory.asn1 \
    ../spaceddir/MyModel-IsNotInSpacedLocation.acn \
    ../spaceddir/MyModel-IsNotInSpacedLocation.asn1
```
The .pro file was not parsed successfully - the files `../spaced dir/*` were not visible in project tree view widget. However after adding quotes (so the snippet looks as below), project parses and building building works. 

```
DISTFILES += \ 
    '../spaced dir/Model-In-Spaced-Location.asn1' \
    '../spaced dir/Model-In-Spaced-Location.acn' \
    '../spaced dir/SecondInSpacedDirectory.acn' \
    '../spaced dir/SecondInSpacedDirectory.asn1' \
    ../spaceddir/MyModel-IsNotInSpacedLocation.acn \
    ../spaceddir/MyModel-IsNotInSpacedLocation.asn1
```

